### PR TITLE
Fix file formatting; Add option to mark questions as Daily Double

### DIFF
--- a/server-utils/convertAndSave.js
+++ b/server-utils/convertAndSave.js
@@ -9,6 +9,7 @@ const QUESTION_TYPE = {
 };
 const TEXT_FONT = "#Palatino Linotype#28#True#False#16777215#";
 const IS_NOT_DAILY_DOUBLE = "N";
+const IS_DAILY_DOUBLE = "Y";
 
 function convertToCustomFormat(questionsByCategory) {
     let output = '';
@@ -16,16 +17,24 @@ function convertToCustomFormat(questionsByCategory) {
     questionsByCategory.forEach(categoryObj => {
         const { category, questions } = categoryObj;
 
-        output += category + '\r';
+        output += category + '\r\n';
 
         questions.forEach(q => {
-            output += q.question + '\r';
-            output += q.answer + ANSWER_TERMINATOR + '\r';
-            output += IS_NOT_DAILY_DOUBLE + '\r';
-            output += QUESTION_TYPE.text + TEXT_FONT + '\r';
+            if (q.isItADailyDouble === false) {
+                output += q.question + '\r\n';
+                output += q.answer + ANSWER_TERMINATOR + '\r\n';
+                output += IS_NOT_DAILY_DOUBLE + '\r\n';
+                output += QUESTION_TYPE.text + TEXT_FONT + '\r\n';
+            }
+            else {
+                output += q.question + '\r\n';
+                output += q.answer + ANSWER_TERMINATOR + '\r\n';
+                output += IS_DAILY_DOUBLE + '\r\n';
+                output += QUESTION_TYPE.text + TEXT_FONT + '\r\n';
+            }
         });
     });
-
+    output += '\r\n^^^\r\n\r\n';
     return output;
 }
 

--- a/server-utils/convertAndSave.js
+++ b/server-utils/convertAndSave.js
@@ -1,17 +1,21 @@
 const fs = require('fs');
 const path = require('path');
 
-const ANSWER_CARET_TERMINATOR = '^^^^';
-const FILE_CARET_TERMINATOR = '^^^';
+const CRLF = '\r\n';
+const CARET_TERMINATOR = {
+    ANSWER: '^^^^',
+    FILE: '^^^',
+};
+const DAILY_DOUBLE = {
+    YES: "Y",
+    NO: "N",
+};
 const QUESTION_TYPE = {
     text: "T",
     photo: "P",
     sound: "S",
 };
 const TEXT_FONT = "#Palatino Linotype#28#True#False#16777215#";
-const IS_NOT_DAILY_DOUBLE = "N";
-const IS_DAILY_DOUBLE = "Y";
-const CRLF = '\r\n';
 
 function convertToCustomFormat(questionsByCategory) {
     let output = '';
@@ -23,12 +27,14 @@ function convertToCustomFormat(questionsByCategory) {
 
         questions.forEach(q => {
             output += q.question + CRLF;
-            output += q.answer + ANSWER_CARET_TERMINATOR + CRLF;
-            output += (q.isItADailyDouble ? IS_DAILY_DOUBLE : IS_NOT_DAILY_DOUBLE) + CRLF;
+            output += q.answer + CARET_TERMINATOR.ANSWER + CRLF;
+            output += (q.isItADailyDouble ? DAILY_DOUBLE.YES : DAILY_DOUBLE.NO) + CRLF;
             output += QUESTION_TYPE.text + TEXT_FONT + CRLF;
         });
     });
-    output += CRLF + FILE_CARET_TERMINATOR + CRLF + CRLF;
+
+    output += CRLF + CARET_TERMINATOR.FILE + CRLF + CRLF;
+
     return output;
 }
 
@@ -39,7 +45,6 @@ function saveCustomFormatFile(data, fileName) {
     }
 
     const filePath = path.join(outputDir, fileName);
-
 
     return new Promise((resolve, reject) => {
         fs.writeFile(filePath, data, (err) => {

--- a/server-utils/convertAndSave.js
+++ b/server-utils/convertAndSave.js
@@ -22,18 +22,10 @@ function convertToCustomFormat(questionsByCategory) {
         output += category + CRLF;
 
         questions.forEach(q => {
-            if (q.isItADailyDouble === true) {
-                output += q.question + CRLF;
-                output += q.answer + ANSWER_CARET_TERMINATOR + CRLF;
-                output += IS_DAILY_DOUBLE + CRLF;
-                output += QUESTION_TYPE.text + TEXT_FONT + CRLF;
-            }
-            else {
-                output += q.question + CRLF;
-                output += q.answer + ANSWER_CARET_TERMINATOR + CRLF;
-                output += IS_NOT_DAILY_DOUBLE + CRLF;
-                output += QUESTION_TYPE.text + TEXT_FONT + CRLF;
-            }
+            output += q.question + CRLF;
+            output += q.answer + ANSWER_CARET_TERMINATOR + CRLF;
+            output += (q.isItADailyDouble ? IS_DAILY_DOUBLE : IS_NOT_DAILY_DOUBLE) + CRLF;
+            output += QUESTION_TYPE.text + TEXT_FONT + CRLF;
         });
     });
     output += CRLF + FILE_CARET_TERMINATOR + CRLF + CRLF;

--- a/server-utils/convertAndSave.js
+++ b/server-utils/convertAndSave.js
@@ -16,13 +16,13 @@ function convertToCustomFormat(questionsByCategory) {
     questionsByCategory.forEach(categoryObj => {
         const { category, questions } = categoryObj;
 
-        output += category + '\n';
+        output += category + '\r';
 
         questions.forEach(q => {
-            output += q.question + '\n';
-            output += q.answer + ANSWER_TERMINATOR + '\n';
-            output += IS_NOT_DAILY_DOUBLE + '\n';
-            output += QUESTION_TYPE.text + TEXT_FONT + '\n';
+            output += q.question + '\r';
+            output += q.answer + ANSWER_TERMINATOR + '\r';
+            output += IS_NOT_DAILY_DOUBLE + '\r';
+            output += QUESTION_TYPE.text + TEXT_FONT + '\r';
         });
     });
 

--- a/server-utils/convertAndSave.js
+++ b/server-utils/convertAndSave.js
@@ -22,16 +22,16 @@ function convertToCustomFormat(questionsByCategory) {
         output += category + CRLF;
 
         questions.forEach(q => {
-            if (q.isItADailyDouble === false) {
+            if (q.isItADailyDouble === true) {
                 output += q.question + CRLF;
                 output += q.answer + ANSWER_CARET_TERMINATOR + CRLF;
-                output += IS_NOT_DAILY_DOUBLE + CRLF;
+                output += IS_DAILY_DOUBLE + CRLF;
                 output += QUESTION_TYPE.text + TEXT_FONT + CRLF;
             }
             else {
                 output += q.question + CRLF;
                 output += q.answer + ANSWER_CARET_TERMINATOR + CRLF;
-                output += IS_DAILY_DOUBLE + CRLF;
+                output += IS_NOT_DAILY_DOUBLE + CRLF;
                 output += QUESTION_TYPE.text + TEXT_FONT + CRLF;
             }
         });

--- a/server-utils/convertAndSave.js
+++ b/server-utils/convertAndSave.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
-const ANSWER_TERMINATOR = '^^^^';
+const ANSWER_CARET_TERMINATOR = '^^^^';
+const FILE_CARET_TERMINATOR = '^^^';
 const QUESTION_TYPE = {
     text: "T",
     photo: "P",
@@ -10,6 +11,7 @@ const QUESTION_TYPE = {
 const TEXT_FONT = "#Palatino Linotype#28#True#False#16777215#";
 const IS_NOT_DAILY_DOUBLE = "N";
 const IS_DAILY_DOUBLE = "Y";
+const CRLF = '\r\n';
 
 function convertToCustomFormat(questionsByCategory) {
     let output = '';
@@ -17,24 +19,24 @@ function convertToCustomFormat(questionsByCategory) {
     questionsByCategory.forEach(categoryObj => {
         const { category, questions } = categoryObj;
 
-        output += category + '\r\n';
+        output += category + CRLF;
 
         questions.forEach(q => {
             if (q.isItADailyDouble === false) {
-                output += q.question + '\r\n';
-                output += q.answer + ANSWER_TERMINATOR + '\r\n';
-                output += IS_NOT_DAILY_DOUBLE + '\r\n';
-                output += QUESTION_TYPE.text + TEXT_FONT + '\r\n';
+                output += q.question + CRLF;
+                output += q.answer + ANSWER_CARET_TERMINATOR + CRLF;
+                output += IS_NOT_DAILY_DOUBLE + CRLF;
+                output += QUESTION_TYPE.text + TEXT_FONT + CRLF;
             }
             else {
-                output += q.question + '\r\n';
-                output += q.answer + ANSWER_TERMINATOR + '\r\n';
-                output += IS_DAILY_DOUBLE + '\r\n';
-                output += QUESTION_TYPE.text + TEXT_FONT + '\r\n';
+                output += q.question + CRLF;
+                output += q.answer + ANSWER_CARET_TERMINATOR + CRLF;
+                output += IS_DAILY_DOUBLE + CRLF;
+                output += QUESTION_TYPE.text + TEXT_FONT + CRLF;
             }
         });
     });
-    output += '\r\n^^^\r\n\r\n';
+    output += CRLF + FILE_CARET_TERMINATOR + CRLF + CRLF;
     return output;
 }
 

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -9,6 +9,7 @@ const EditableQuestionAnswerPair = ({
     onQuestionChange,
     onAnswerChange,
     setDifficulty,
+    setDailyDouble,
 }) => {
     const difficultyLevels = [
         { value: 0, label: "Easy" },
@@ -54,6 +55,16 @@ const EditableQuestionAnswerPair = ({
                         {label}
                     </Button>
                 ))}
+                <div>
+                    <label>
+                        <input
+                            type="checkbox"
+                            checked={false}
+                            onChange={() => setDailyDouble(index, true)}
+                        />
+                        Daily Double?
+                    </label>
+                </div>
             </ButtonGroup>
         </div>
     );

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -1,5 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, ButtonGroup, TextField } from '@mui/material';
+
+const DIFFICULTY_LEVELS = [
+    { value: 0, label: "Easy" },
+    { value: 1, label: "Medium" },
+    { value: 2, label: "Difficult" },
+];
 
 const EditableQuestionAnswerPair = ({
     question,
@@ -11,11 +17,12 @@ const EditableQuestionAnswerPair = ({
     setDifficulty,
     setDailyDouble,
 }) => {
-    const difficultyLevels = [
-        { value: 0, label: "Easy" },
-        { value: 1, label: "Medium" },
-        { value: 2, label: "Difficult" },
-    ];
+    const [isChecked, setIsChecked] = useState(false);
+
+    const handleCheckboxChange = () => {
+        setIsChecked(!isChecked);
+        setDailyDouble(index, !isChecked);
+    }
 
     return (
         <div className="question-answer-pair">
@@ -39,7 +46,7 @@ const EditableQuestionAnswerPair = ({
             />
             <span className="question-index">Q {index}</span>
             <ButtonGroup variant="contained" aria-label="outlined primary button group">
-                {difficultyLevels.map(({ value, label }) => (
+                {DIFFICULTY_LEVELS.map(({ value, label }) => (
                     <Button
                         sx={{
                             backgroundColor: difficulty === value ? '#3f51b5' : '#fff',
@@ -59,8 +66,8 @@ const EditableQuestionAnswerPair = ({
                     <label>
                         <input
                             type="checkbox"
-                            checked={false}
-                            onChange={() => setDailyDouble(index, true)}
+                            checked={isChecked}
+                            onChange={handleCheckboxChange}
                         />
                         Daily Double?
                     </label>

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -149,7 +149,6 @@ const TriviaGenerator = () => {
                                 return question;
                             }),
                         };
-
                     }
                     return categoryObj;
                 });
@@ -157,6 +156,18 @@ const TriviaGenerator = () => {
         );
     };
 
+    const updateIsDailyDouble = (category, questionIndex, newDDStatus) => {
+        setQuestionsByCategory((prevState) => {
+            const updatedQuestionsByCategory = [...prevState];
+            const categoryIndex = updatedQuestionsByCategory.findIndex(
+                (item) => item.category === category
+            );
+            updatedQuestionsByCategory[categoryIndex].questions[
+                questionIndex
+            ].isItADailyDouble = newDDStatus;
+            return updatedQuestionsByCategory;
+        });
+    };
 
     return (
         <Container
@@ -204,6 +215,10 @@ const TriviaGenerator = () => {
                                     setDifficulty={
                                         (index, diffiRank) =>
                                             updateDifficulty(categoryObj.category, index, diffiRank)
+                                    }
+                                    setDailyDouble={
+                                        (index) =>
+                                            updateIsDailyDouble()
                                     }
                                 />
                             ))}

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -217,8 +217,8 @@ const TriviaGenerator = () => {
                                             updateDifficulty(categoryObj.category, index, diffiRank)
                                     }
                                     setDailyDouble={
-                                        (index) =>
-                                            updateIsDailyDouble()
+                                        (index, isDD) =>
+                                            updateIsDailyDouble(categoryObj.category, index, isDD)
                                     }
                                 />
                             ))}


### PR DESCRIPTION
This PR aims to accomplish two things:

1. Fixes the file formatting issue encountered when attempting to open/read files on the trivia hosting software. Investigation found that the software wants to see the Windows-esque CRLF characters as line breaks.
2. Adds an option for each question to be marked as a Daily Double. As part of this PR, limits are not placed on how many questions can be marked (this will likely come later).