### PR TITLE
Minor Styling Updates

### DIFF
--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -40,7 +40,7 @@ const EditableQuestionAnswerPair = ({
                 id={`question-${index}`}
                 value={question}
                 onChange={(event) => onQuestionChange(index, event.target.value)}
-                label={`# ${index}`}
+                label="Question"
                 className="question-textarea"
                 variant="outlined"
                 multiline

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -8,6 +8,7 @@ import {
     Radio,
     RadioGroup,
     TextField,
+    Typography,
 } from '@mui/material';
 
 const DIFFICULTY_LEVELS = [
@@ -54,7 +55,7 @@ const EditableQuestionAnswerPair = ({
                 variant="outlined"
                 multiline
             />
-            <span className="question-index">Q {index}</span>
+            <Typography variant="body1">Q {index}</Typography>
             <FormControl component="fieldset">
                 <RadioGroup
                     row

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import {
     Button,
     ButtonGroup,
+    Checkbox,
     FormControl,
     FormControlLabel,
     Radio,
@@ -84,17 +85,16 @@ const EditableQuestionAnswerPair = ({
                         {label}
                     </Button>
                 ))}
-                <div>
-                    <label>
-                        <input
-                            type="checkbox"
-                            checked={isChecked}
-                            onChange={handleCheckboxChange}
-                        />
-                        Daily Double?
-                    </label>
-                </div>
             </ButtonGroup>
+            <FormControlLabel
+                control={
+                    <Checkbox
+                        checked={isChecked}
+                        onChange={handleCheckboxChange}
+                    />
+                }
+                label="Daily Double?"
+            />
         </div>
     );
 };

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -55,7 +55,7 @@ const EditableQuestionAnswerPair = ({
                 variant="outlined"
                 multiline
             />
-            <Typography variant="body1">Q {index}</Typography>
+            <Typography variant="body1">Q {index + 1}</Typography>
             <FormControl component="fieldset">
                 <RadioGroup
                     row


### PR DESCRIPTION
This PR contains a few minor changes to the styling of the EditableQuestionAnswerPair component:

- replaces the native span and checkbox tags with Material UI components
- replaces the (internal) index on the question fields with the word "Question"
- displays the one-based ordinal number of the question (this is what a "normal user" would expect to see)

BEFORE & AFTER PICS:

(before)
<img width="808" alt="Screenshot 2023-06-05 at 8 21 42 AM" src="https://github.com/jduffey/gpt-trivia-assist/assets/22714448/1a508622-080b-481d-a929-b73aaf2be4f7">

(after)
<img width="807" alt="Screenshot 2023-06-05 at 8 20 38 AM" src="https://github.com/jduffey/gpt-trivia-assist/assets/22714448/bca24520-4113-4177-be00-dd0763242ddb">
