### PR TITLE
Image and audio categories

### DIFF
--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -40,7 +40,7 @@ const EditableQuestionAnswerPair = ({
                 id={`question-${index}`}
                 value={question}
                 onChange={(event) => onQuestionChange(index, event.target.value)}
-                label={`# ${index}`}
+                label="Question"
                 className="question-textarea"
                 variant="outlined"
                 multiline

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -8,6 +8,7 @@ import {
     Radio,
     RadioGroup,
     TextField,
+    Typography,
 } from '@mui/material';
 
 const DIFFICULTY_LEVELS = [
@@ -54,7 +55,7 @@ const EditableQuestionAnswerPair = ({
                 variant="outlined"
                 multiline
             />
-            <span className="question-index">Q {index}</span>
+            <Typography variant="body1">Q {index}</Typography>
             <FormControl component="fieldset">
                 <RadioGroup
                     row

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import {
     Button,
     ButtonGroup,
+    Checkbox,
     FormControl,
     FormControlLabel,
     Radio,
@@ -84,17 +85,16 @@ const EditableQuestionAnswerPair = ({
                         {label}
                     </Button>
                 ))}
-                <div>
-                    <label>
-                        <input
-                            type="checkbox"
-                            checked={isChecked}
-                            onChange={handleCheckboxChange}
-                        />
-                        Daily Double?
-                    </label>
-                </div>
             </ButtonGroup>
+            <FormControlLabel
+                control={
+                    <Checkbox
+                        checked={isChecked}
+                        onChange={handleCheckboxChange}
+                    />
+                }
+                label="Daily Double?"
+            />
         </div>
     );
 };

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -55,7 +55,7 @@ const EditableQuestionAnswerPair = ({
                 variant="outlined"
                 multiline
             />
-            <Typography variant="body1">Q {index}</Typography>
+            <Typography variant="body1">Q {index + 1}</Typography>
             <FormControl component="fieldset">
                 <RadioGroup
                     row

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -18,6 +18,7 @@ const DIFFICULTY_LEVELS = [
 ];
 
 const EditableQuestionAnswerPair = ({
+    categoryType,
     question,
     answer,
     difficulty,
@@ -61,7 +62,7 @@ const EditableQuestionAnswerPair = ({
                     row
                     aria-label="position"
                     name="position"
-                    defaultValue="T"
+                    value={categoryType}
                     onChange={(event) => setQuestionType(index, event.target.value)}
                 >
                     <FormControlLabel value="T" control={<Radio color="primary" />} label="Text" />

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -10,6 +10,7 @@ const DEFAULT_NUM_QUESTIONS = 7;
 
 const TriviaGenerator = () => {
     const [error, setError] = useState('');
+    const [categoryType, setCategoryType] = useState('T');
     const [categoryInput, setCategoryInput] = useState('');
     const [questionsByCategory, setQuestionsByCategory] = useState([]);
     const [dataLoaded, setDataLoaded] = useState(false);
@@ -35,6 +36,7 @@ const TriviaGenerator = () => {
                     ...prevState,
                     {
                         category: categoryInput,
+                        categoryType,
                         questions: response.data,
                     },
                 ];
@@ -195,6 +197,8 @@ const TriviaGenerator = () => {
             <h1 className="main-title">Trivia Generator</h1>
             <TriviaInputForm
                 className="input-form"
+                categoryType={categoryType}
+                setCategoryType={setCategoryType}
                 categoryInput={categoryInput}
                 setCategoryInput={setCategoryInput}
                 numQuestions={numQuestions}

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -22,63 +22,40 @@ const TriviaGenerator = () => {
         e.preventDefault();
         setError('');
 
-        if (categoryType !== 'T') {
-            setQuestionsByCategory((prevState) => {
-                [...prevState].map((categoryObj) => {
-                    categoryObj.questions = categoryObj.questions.filter(
-                        (question) => typeof question.difficulty !== "undefined"
-                    );
-                    return categoryObj;
-                });
+        const addQuestionType = (data, type) => data.map(item => ({ ...item, questionType: type }));
 
-                return [
-                    ...prevState,
-                    {
-                        category: categoryInput,
-                        questions: [
-                            { question: '', answer: '', questionType: categoryType },
-                            { question: '', answer: '', questionType: categoryType },
-                            { question: '', answer: '', questionType: categoryType },
-                            { question: '', answer: '', questionType: categoryType },
-                            { question: '', answer: '', questionType: categoryType },
-                        ],
-                    },
-                ];
+        const removeQuestionsWithoutDifficultyRating = (categories) =>
+            categories.map(categoryObj => {
+                categoryObj.questions = categoryObj.questions.filter(
+                    question => typeof question.difficulty !== "undefined"
+                );
+                return categoryObj;
             });
 
-            setDataLoaded(true);
-        } else {
-            try {
-                const response = await axios.post('/generate', { categoryInput, numQuestions: numQuestions });
-                console.log(response.data);
-
-                setQuestionsByCategory((prevState) => {
-                    [...prevState].map((categoryObj) => {
-                        categoryObj.questions = categoryObj.questions.filter(
-                            (question) => typeof question.difficulty !== "undefined"
-                        );
-                        return categoryObj;
-                    });
-
-                    return [
-                        ...prevState,
-                        {
-                            category: categoryInput,
-                            questions: response.data.map((qaPair) => {
-                                return {
-                                    ...qaPair,
-                                    questionType: categoryType,
-                                };
-                            }),
-                        },
-                    ];
-                });
-
-                setDataLoaded(true);
-            } catch (err) {
-                setError('Error generating trivia questions');
+        const addCategoryToState = async (type) => {
+            let questions;
+            if (type === 'T') {
+                try {
+                    const response = await axios.post('/generate', { categoryInput, numQuestions: numQuestions });
+                    console.log(response.data);
+                    questions = addQuestionType(response.data, type);
+                } catch (err) {
+                    setError('Error generating trivia questions');
+                    return;
+                }
+            } else {
+                questions = Array(5).fill({ question: '', answer: '', questionType: type });
             }
-        }
+
+            setQuestionsByCategory(prevState => [
+                ...removeQuestionsWithoutDifficultyRating(prevState),
+                { category: categoryInput, questions }
+            ]);
+
+            setDataLoaded(true);
+        };
+
+        addCategoryToState(categoryType);
     };
 
     const handleSave = async () => {

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -94,7 +94,7 @@ const TriviaGenerator = () => {
         }
     };
 
-    const updateQuestionAttribute = (category, questionIndex, attribute, newValue) => {
+    const updateQuestion = (category, questionIndex, newQuestionValue) => {
         setQuestionsByCategory((prevState) => {
             const updatedQuestionsByCategory = [...prevState];
             const categoryIndex = updatedQuestionsByCategory.findIndex(
@@ -102,7 +102,20 @@ const TriviaGenerator = () => {
             );
             updatedQuestionsByCategory[categoryIndex].questions[
                 questionIndex
-            ][attribute] = newValue;
+            ].question = newQuestionValue;
+            return updatedQuestionsByCategory;
+        });
+    };
+
+    const updateAnswer = (category, questionIndex, newAnswerValue) => {
+        setQuestionsByCategory((prevState) => {
+            const updatedQuestionsByCategory = [...prevState];
+            const categoryIndex = updatedQuestionsByCategory.findIndex(
+                (item) => item.category === category
+            );
+            updatedQuestionsByCategory[categoryIndex].questions[
+                questionIndex
+            ].answer = newAnswerValue;
             return updatedQuestionsByCategory;
         });
     };
@@ -154,6 +167,32 @@ const TriviaGenerator = () => {
         );
     };
 
+    const updateIsDailyDouble = (category, questionIndex, newDDStatus) => {
+        setQuestionsByCategory((prevState) => {
+            const updatedQuestionsByCategory = [...prevState];
+            const categoryIndex = updatedQuestionsByCategory.findIndex(
+                (item) => item.category === category
+            );
+            updatedQuestionsByCategory[categoryIndex].questions[
+                questionIndex
+            ].isItADailyDouble = newDDStatus;
+            return updatedQuestionsByCategory;
+        });
+    };
+
+    const updateQuestionType = (category, questionIndex, newQuestionTypeStatus) => {
+        setQuestionsByCategory((prevState) => {
+            const updatedQuestionsByCategory = [...prevState];
+            const categoryIndex = updatedQuestionsByCategory.findIndex(
+                (item) => item.category === category
+            );
+            updatedQuestionsByCategory[categoryIndex].questions[
+                questionIndex
+            ].questionType = newQuestionTypeStatus;
+            return updatedQuestionsByCategory;
+        });
+    };
+
     return (
         <Container
             sx={{
@@ -194,11 +233,11 @@ const TriviaGenerator = () => {
                                     difficulty={questionObj.difficulty}
                                     onQuestionChange={
                                         (index, value) =>
-                                            updateQuestionAttribute(categoryObj.category, index, 'question', value)
+                                            updateQuestion(categoryObj.category, index, value)
                                     }
                                     onAnswerChange={
                                         (index, value) =>
-                                            updateQuestionAttribute(categoryObj.category, index, 'answer', value)
+                                            updateAnswer(categoryObj.category, index, value)
                                     }
                                     setDifficulty={
                                         (index, diffiRank) =>
@@ -206,11 +245,11 @@ const TriviaGenerator = () => {
                                     }
                                     setDailyDouble={
                                         (index, isDD) =>
-                                            updateQuestionAttribute(categoryObj.category, index, 'isItADailyDouble', isDD)
+                                            updateIsDailyDouble(categoryObj.category, index, isDD)
                                     }
                                     setQuestionType={
                                         (index, qType) =>
-                                            updateQuestionAttribute(categoryObj.category, index, 'questionType', qType)
+                                            updateQuestionType(categoryObj.category, index, qType)
                                     }
                                 />
                             ))}

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -17,6 +17,13 @@ const TriviaGenerator = () => {
     const [numQuestions, setNumQuestions] = useState(DEFAULT_NUM_QUESTIONS);
 
     const handleSubmit = async (e) => {
+        console.log("Submit button w/ category type:", categoryType);
+
+        if (categoryType !== 'T') {
+            console.log('Need to create 5 blank pairs');
+            return;
+        }
+
         setDataLoaded(false);
         e.preventDefault();
         setError('');

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -94,7 +94,7 @@ const TriviaGenerator = () => {
         }
     };
 
-    const updateQuestion = (category, questionIndex, newQuestionValue) => {
+    const updateQuestionAttribute = (category, questionIndex, attribute, newValue) => {
         setQuestionsByCategory((prevState) => {
             const updatedQuestionsByCategory = [...prevState];
             const categoryIndex = updatedQuestionsByCategory.findIndex(
@@ -102,20 +102,7 @@ const TriviaGenerator = () => {
             );
             updatedQuestionsByCategory[categoryIndex].questions[
                 questionIndex
-            ].question = newQuestionValue;
-            return updatedQuestionsByCategory;
-        });
-    };
-
-    const updateAnswer = (category, questionIndex, newAnswerValue) => {
-        setQuestionsByCategory((prevState) => {
-            const updatedQuestionsByCategory = [...prevState];
-            const categoryIndex = updatedQuestionsByCategory.findIndex(
-                (item) => item.category === category
-            );
-            updatedQuestionsByCategory[categoryIndex].questions[
-                questionIndex
-            ].answer = newAnswerValue;
+            ][attribute] = newValue;
             return updatedQuestionsByCategory;
         });
     };
@@ -167,32 +154,6 @@ const TriviaGenerator = () => {
         );
     };
 
-    const updateIsDailyDouble = (category, questionIndex, newDDStatus) => {
-        setQuestionsByCategory((prevState) => {
-            const updatedQuestionsByCategory = [...prevState];
-            const categoryIndex = updatedQuestionsByCategory.findIndex(
-                (item) => item.category === category
-            );
-            updatedQuestionsByCategory[categoryIndex].questions[
-                questionIndex
-            ].isItADailyDouble = newDDStatus;
-            return updatedQuestionsByCategory;
-        });
-    };
-
-    const updateQuestionType = (category, questionIndex, newQuestionTypeStatus) => {
-        setQuestionsByCategory((prevState) => {
-            const updatedQuestionsByCategory = [...prevState];
-            const categoryIndex = updatedQuestionsByCategory.findIndex(
-                (item) => item.category === category
-            );
-            updatedQuestionsByCategory[categoryIndex].questions[
-                questionIndex
-            ].questionType = newQuestionTypeStatus;
-            return updatedQuestionsByCategory;
-        });
-    };
-
     return (
         <Container
             sx={{
@@ -233,11 +194,11 @@ const TriviaGenerator = () => {
                                     difficulty={questionObj.difficulty}
                                     onQuestionChange={
                                         (index, value) =>
-                                            updateQuestion(categoryObj.category, index, value)
+                                            updateQuestionAttribute(categoryObj.category, index, 'question', value)
                                     }
                                     onAnswerChange={
                                         (index, value) =>
-                                            updateAnswer(categoryObj.category, index, value)
+                                            updateQuestionAttribute(categoryObj.category, index, 'answer', value)
                                     }
                                     setDifficulty={
                                         (index, diffiRank) =>
@@ -245,11 +206,11 @@ const TriviaGenerator = () => {
                                     }
                                     setDailyDouble={
                                         (index, isDD) =>
-                                            updateIsDailyDouble(categoryObj.category, index, isDD)
+                                            updateQuestionAttribute(categoryObj.category, index, 'isItADailyDouble', isDD)
                                     }
                                     setQuestionType={
                                         (index, qType) =>
-                                            updateQuestionType(categoryObj.category, index, qType)
+                                            updateQuestionAttribute(categoryObj.category, index, 'questionType', qType)
                                     }
                                 />
                             ))}

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -22,40 +22,63 @@ const TriviaGenerator = () => {
         e.preventDefault();
         setError('');
 
-        const addQuestionType = (data, type) => data.map(item => ({ ...item, questionType: type }));
+        if (categoryType !== 'T') {
+            setQuestionsByCategory((prevState) => {
+                [...prevState].map((categoryObj) => {
+                    categoryObj.questions = categoryObj.questions.filter(
+                        (question) => typeof question.difficulty !== "undefined"
+                    );
+                    return categoryObj;
+                });
 
-        const removeQuestionsWithoutDifficultyRating = (categories) =>
-            categories.map(categoryObj => {
-                categoryObj.questions = categoryObj.questions.filter(
-                    question => typeof question.difficulty !== "undefined"
-                );
-                return categoryObj;
+                return [
+                    ...prevState,
+                    {
+                        category: categoryInput,
+                        questions: [
+                            { question: '', answer: '', questionType: categoryType },
+                            { question: '', answer: '', questionType: categoryType },
+                            { question: '', answer: '', questionType: categoryType },
+                            { question: '', answer: '', questionType: categoryType },
+                            { question: '', answer: '', questionType: categoryType },
+                        ],
+                    },
+                ];
             });
 
-        const addCategoryToState = async (type) => {
-            let questions;
-            if (type === 'T') {
-                try {
-                    const response = await axios.post('/generate', { categoryInput, numQuestions: numQuestions });
-                    console.log(response.data);
-                    questions = addQuestionType(response.data, type);
-                } catch (err) {
-                    setError('Error generating trivia questions');
-                    return;
-                }
-            } else {
-                questions = Array(5).fill({ question: '', answer: '', questionType: type });
-            }
-
-            setQuestionsByCategory(prevState => [
-                ...removeQuestionsWithoutDifficultyRating(prevState),
-                { category: categoryInput, questions }
-            ]);
-
             setDataLoaded(true);
-        };
+        } else {
+            try {
+                const response = await axios.post('/generate', { categoryInput, numQuestions: numQuestions });
+                console.log(response.data);
 
-        addCategoryToState(categoryType);
+                setQuestionsByCategory((prevState) => {
+                    [...prevState].map((categoryObj) => {
+                        categoryObj.questions = categoryObj.questions.filter(
+                            (question) => typeof question.difficulty !== "undefined"
+                        );
+                        return categoryObj;
+                    });
+
+                    return [
+                        ...prevState,
+                        {
+                            category: categoryInput,
+                            questions: response.data.map((qaPair) => {
+                                return {
+                                    ...qaPair,
+                                    questionType: categoryType,
+                                };
+                            }),
+                        },
+                    ];
+                });
+
+                setDataLoaded(true);
+            } catch (err) {
+                setError('Error generating trivia questions');
+            }
+        }
     };
 
     const handleSave = async () => {

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -35,13 +35,12 @@ const TriviaGenerator = () => {
                     ...prevState,
                     {
                         category: categoryInput,
-                        categoryType,
                         questions: [
-                            { question: '', answer: '' },
-                            { question: '', answer: '' },
-                            { question: '', answer: '' },
-                            { question: '', answer: '' },
-                            { question: '', answer: '' },
+                            { question: '', answer: '', questionType: categoryType },
+                            { question: '', answer: '', questionType: categoryType },
+                            { question: '', answer: '', questionType: categoryType },
+                            { question: '', answer: '', questionType: categoryType },
+                            { question: '', answer: '', questionType: categoryType },
                         ],
                     },
                 ];
@@ -65,8 +64,12 @@ const TriviaGenerator = () => {
                         ...prevState,
                         {
                             category: categoryInput,
-                            categoryType,
-                            questions: response.data,
+                            questions: response.data.map((qaPair) => {
+                                return {
+                                    ...qaPair,
+                                    questionType: categoryType,
+                                };
+                            }),
                         },
                     ];
                 });
@@ -247,6 +250,7 @@ const TriviaGenerator = () => {
                                     key={index}
                                     index={index}
                                     className="editable-pair"
+                                    categoryType={questionObj.questionType}
                                     question={questionObj.question}
                                     answer={questionObj.answer}
                                     difficulty={questionObj.difficulty}
@@ -267,8 +271,8 @@ const TriviaGenerator = () => {
                                             updateIsDailyDouble(categoryObj.category, index, isDD)
                                     }
                                     setQuestionType={
-                                        (index, questionType) =>
-                                            updateQuestionType(categoryObj.category, index, questionType)
+                                        (index, qType) =>
+                                            updateQuestionType(categoryObj.category, index, qType)
                                     }
                                 />
                             ))}

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -17,6 +17,7 @@ const TriviaGenerator = () => {
     const [numQuestions, setNumQuestions] = useState(DEFAULT_NUM_QUESTIONS);
 
     const handleSubmit = async (e) => {
+        console.log("Submit button w/ category type:", categoryType);
         setDataLoaded(false);
         e.preventDefault();
         setError('');
@@ -200,16 +201,16 @@ const TriviaGenerator = () => {
                                             updateQuestionAttribute(categoryObj.category, index, 'answer', value)
                                     }
                                     setDifficulty={
-                                        (index, value) =>
-                                            updateDifficulty(categoryObj.category, index, value)
+                                        (index, diffiRank) =>
+                                            updateDifficulty(categoryObj.category, index, diffiRank)
                                     }
                                     setDailyDouble={
-                                        (index, value) =>
-                                            updateQuestionAttribute(categoryObj.category, index, 'isItADailyDouble', value)
+                                        (index, isDD) =>
+                                            updateQuestionAttribute(categoryObj.category, index, 'isItADailyDouble', isDD)
                                     }
                                     setQuestionType={
-                                        (index, value) =>
-                                            updateQuestionAttribute(categoryObj.category, index, 'questionType', value)
+                                        (index, qType) =>
+                                            updateQuestionAttribute(categoryObj.category, index, 'questionType', qType)
                                     }
                                 />
                             ))}

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -17,7 +17,6 @@ const TriviaGenerator = () => {
     const [numQuestions, setNumQuestions] = useState(DEFAULT_NUM_QUESTIONS);
 
     const handleSubmit = async (e) => {
-        console.log("Submit button w/ category type:", categoryType);
         setDataLoaded(false);
         e.preventDefault();
         setError('');
@@ -201,16 +200,16 @@ const TriviaGenerator = () => {
                                             updateQuestionAttribute(categoryObj.category, index, 'answer', value)
                                     }
                                     setDifficulty={
-                                        (index, diffiRank) =>
-                                            updateDifficulty(categoryObj.category, index, diffiRank)
+                                        (index, value) =>
+                                            updateDifficulty(categoryObj.category, index, value)
                                     }
                                     setDailyDouble={
-                                        (index, isDD) =>
-                                            updateQuestionAttribute(categoryObj.category, index, 'isItADailyDouble', isDD)
+                                        (index, value) =>
+                                            updateQuestionAttribute(categoryObj.category, index, 'isItADailyDouble', value)
                                     }
                                     setQuestionType={
-                                        (index, qType) =>
-                                            updateQuestionAttribute(categoryObj.category, index, 'questionType', qType)
+                                        (index, value) =>
+                                            updateQuestionAttribute(categoryObj.category, index, 'questionType', value)
                                     }
                                 />
                             ))}

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -18,19 +18,11 @@ const TriviaGenerator = () => {
 
     const handleSubmit = async (e) => {
         console.log("Submit button w/ category type:", categoryType);
-
-        if (categoryType !== 'T') {
-            console.log('Need to create 5 blank pairs');
-            return;
-        }
-
         setDataLoaded(false);
         e.preventDefault();
         setError('');
 
-        try {
-            const response = await axios.post('/generate', { categoryInput, numQuestions: numQuestions });
-
+        if (categoryType !== 'T') {
             setQuestionsByCategory((prevState) => {
                 [...prevState].map((categoryObj) => {
                     categoryObj.questions = categoryObj.questions.filter(
@@ -44,14 +36,45 @@ const TriviaGenerator = () => {
                     {
                         category: categoryInput,
                         categoryType,
-                        questions: response.data,
+                        questions: [
+                            { question: '', answer: '' },
+                            { question: '', answer: '' },
+                            { question: '', answer: '' },
+                            { question: '', answer: '' },
+                            { question: '', answer: '' },
+                        ],
                     },
                 ];
             });
 
             setDataLoaded(true);
-        } catch (err) {
-            setError('Error generating trivia questions');
+        } else {
+            try {
+                const response = await axios.post('/generate', { categoryInput, numQuestions: numQuestions });
+                console.log(response.data);
+
+                setQuestionsByCategory((prevState) => {
+                    [...prevState].map((categoryObj) => {
+                        categoryObj.questions = categoryObj.questions.filter(
+                            (question) => typeof question.difficulty !== "undefined"
+                        );
+                        return categoryObj;
+                    });
+
+                    return [
+                        ...prevState,
+                        {
+                            category: categoryInput,
+                            categoryType,
+                            questions: response.data,
+                        },
+                    ];
+                });
+
+                setDataLoaded(true);
+            } catch (err) {
+                setError('Error generating trivia questions');
+            }
         }
     };
 

--- a/src/TriviaInputForm.js
+++ b/src/TriviaInputForm.js
@@ -19,8 +19,6 @@ const TriviaInputForm = ({
     onSubmit,
     dataLoaded,
 }) => {
-    console.log("TriviaInputForm categoryType:", categoryType);
-
     const [elapsedSeconds, setElapsedSeconds] = useState(0);
     const [timerActive, setTimerActive] = useState(false);
 
@@ -43,7 +41,9 @@ const TriviaInputForm = ({
     const handleSubmit = (e) => {
         e.preventDefault();
         setElapsedSeconds(0);
-        setTimerActive(true);
+        if (categoryType === 'T') {
+            setTimerActive(true)
+        };
         onSubmit(e);
     };
 

--- a/src/TriviaInputForm.js
+++ b/src/TriviaInputForm.js
@@ -10,6 +10,8 @@ import {
 } from '@mui/material';
 
 const TriviaInputForm = ({
+    categoryType,
+    setCategoryType,
     categoryInput,
     setCategoryInput,
     numQuestions,
@@ -17,6 +19,8 @@ const TriviaInputForm = ({
     onSubmit,
     dataLoaded,
 }) => {
+    console.log("TriviaInputForm categoryType:", categoryType);
+
     const [elapsedSeconds, setElapsedSeconds] = useState(0);
     const [timerActive, setTimerActive] = useState(false);
 
@@ -50,8 +54,8 @@ const TriviaInputForm = ({
                     row
                     aria-label="position"
                     name="position"
-                    defaultValue="T"
-                    // onChange={(event) => setQuestionType(index, event.target.value)}
+                    value={categoryType}
+                    onChange={(event) => setCategoryType(event.target.value)}
                 >
                     <FormControlLabel value="T" control={<Radio color="primary" />} label="Text" />
                     <FormControlLabel value="P" control={<Radio color="primary" />} label="Image" />

--- a/src/TriviaInputForm.js
+++ b/src/TriviaInputForm.js
@@ -1,5 +1,13 @@
 import React, { useState, useEffect } from 'react';
-import { Button, LinearProgress, TextField } from '@mui/material';
+import {
+    Button,
+    FormControl,
+    FormControlLabel,
+    LinearProgress,
+    Radio,
+    RadioGroup,
+    TextField
+} from '@mui/material';
 
 const TriviaInputForm = ({
     categoryInput,
@@ -37,6 +45,19 @@ const TriviaInputForm = ({
 
     return (
         <form onSubmit={handleSubmit} className="trivia-form">
+            <FormControl component="fieldset">
+                <RadioGroup
+                    row
+                    aria-label="position"
+                    name="position"
+                    defaultValue="T"
+                    // onChange={(event) => setQuestionType(index, event.target.value)}
+                >
+                    <FormControlLabel value="T" control={<Radio color="primary" />} label="Text" />
+                    <FormControlLabel value="P" control={<Radio color="primary" />} label="Image" />
+                    <FormControlLabel value="S" control={<Radio color="primary" />} label="Audio" />
+                </RadioGroup>
+            </FormControl>
             <TextField
                 id="categoryInput"
                 label="Category"

--- a/src/TriviaInputForm.js
+++ b/src/TriviaInputForm.js
@@ -71,6 +71,7 @@ const TriviaInputForm = ({
             />
             <TextField
                 id="numQuestions-input"
+                disabled={categoryType !== 'T'}
                 label="# Q's"
                 type="number"
                 inputProps={{ min: "1" }}

--- a/src/TriviaInputForm.js
+++ b/src/TriviaInputForm.js
@@ -75,7 +75,7 @@ const TriviaInputForm = ({
                 label="# Q's"
                 type="number"
                 inputProps={{ min: "1" }}
-                value={numQuestions}
+                value={categoryType === 'T' ? numQuestions : 5}
                 onChange={(e) => setNumQuestions(Number(e.target.value))}
                 className="num-questions-input"
             />
@@ -83,7 +83,9 @@ const TriviaInputForm = ({
                 variant="contained"
                 type="submit"
             >
-                {`Generate ${numQuestions} Questions`}
+                {categoryType === 'T' ?
+                    `Generate ${numQuestions} Questions`
+                    : 'Create 5 Blank Pairs'}
             </Button>
             {timerActive && !dataLoaded &&
                 <p className="elapsed-time">


### PR DESCRIPTION
Category input form at top lets user select between "Text", "Image", and "Audio" categories. If Image or Audio are selected:

- Number of questions text field becomes disabled and "5" is displayed inside
- Text of blue "submit" button is changed
- Five blank Q/A pairs are generated with each pair defaulting to the selected category

Users can also individually assign a ~~category~~ type to questions once their Q/A pair fields have been generated.

The Text/Image/Audio selection results in a "T", "P", or "S" being sent to the resulting text file (with the same font styling indicator string if the selection is "T")