### PR TITLE
Populate Image and Audio File Names

### DIFF
--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -46,8 +46,12 @@ const EditableQuestionAnswerPair = ({
 
         input.onchange = (event) => {
             const file = event.target.files[0];
-            const questionFieldText = `J:\\${folderNameInput}\\${categoryName}\\${file.name}`;
+            const fileName = file.name;
+            const questionFieldText = `J:\\${folderNameInput}\\${categoryName}\\${fileName}`;
             onQuestionChange(index, questionFieldText);
+
+            const fileNameWithoutExtension = fileName.split('.')[0];
+            onAnswerChange(index, fileNameWithoutExtension);
         };
 
         input.click();

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -37,6 +37,10 @@ const EditableQuestionAnswerPair = ({
         setDailyDouble(index, !isChecked);
     }
 
+    const handleImageUploadClick = () => {
+        alert("You clicked the UPLOAD button!");
+    }
+
     return (
         <div className="question-answer-pair">
             <TextField
@@ -66,7 +70,8 @@ const EditableQuestionAnswerPair = ({
                         backgroundColor: 'pink',
                         transition: '0s',
                     },
-                }}>
+                }}
+                onClick={handleImageUploadClick}>
                 Upload
             </Button>
             <FormControl component="fieldset">

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -58,6 +58,17 @@ const EditableQuestionAnswerPair = ({
                 multiline
             />
             <Typography variant="body1">Q {index + 1}</Typography>
+            <Button
+                sx={{
+                    backgroundColor: '#3f51b5',
+                    color: '#fff',
+                    '&:hover': {
+                        backgroundColor: 'pink',
+                        transition: '0s',
+                    },
+                }}>
+                Upload
+            </Button>
             <FormControl component="fieldset">
                 <RadioGroup
                     row

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -18,6 +18,8 @@ const DIFFICULTY_LEVELS = [
 ];
 
 const EditableQuestionAnswerPair = ({
+    folderNameInput,
+    categoryName,
     categoryType,
     question,
     answer,
@@ -43,8 +45,9 @@ const EditableQuestionAnswerPair = ({
         input.accept = "image/*";
 
         input.onchange = (event) => {
-            const filePath = event.target.value;
-            onQuestionChange(index, filePath);
+            const file = event.target.files[0];
+            const questionFieldText = `J:\\${folderNameInput}\\${categoryName}\\${file.name}`;
+            onQuestionChange(index, questionFieldText);
         };
 
         input.click();

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -38,8 +38,17 @@ const EditableQuestionAnswerPair = ({
     }
 
     const handleImageUploadClick = () => {
-        alert("You clicked the UPLOAD button!");
-    }
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = "image/*";
+
+        input.onchange = (event) => {
+            const file = event.target.files[0];
+            console.log("Selected file:", file.name);
+        };
+
+        input.click();
+    };
 
     return (
         <div className="question-answer-pair">

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -43,9 +43,8 @@ const EditableQuestionAnswerPair = ({
         input.accept = "image/*";
 
         input.onchange = (event) => {
-            const file = event.target.files[0];
-            console.log("Selected file:", file.name);
-            onQuestionChange(index, file.name);
+            const filePath = event.target.value;
+            onQuestionChange(index, filePath);
         };
 
         input.click();

--- a/src/EditableQuestionAnswerPair.js
+++ b/src/EditableQuestionAnswerPair.js
@@ -45,6 +45,7 @@ const EditableQuestionAnswerPair = ({
         input.onchange = (event) => {
             const file = event.target.files[0];
             console.log("Selected file:", file.name);
+            onQuestionChange(index, file.name);
         };
 
         input.click();

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -258,6 +258,8 @@ const TriviaGenerator = () => {
                                     key={index}
                                     index={index}
                                     className="editable-pair"
+                                    folderNameInput={folderNameInput}
+                                    categoryName={categoryObj.category}
                                     categoryType={questionObj.questionType}
                                     question={questionObj.question}
                                     answer={questionObj.answer}


### PR DESCRIPTION
- When category is image or audio, an upload button appears that allows the user to select a file from the file system
- The question field is populated with a hardcoded "J:\" drive (this is a peculiar artifact of the singular use case of this app as of the time of this PR), the custom folder name, the category name, and the file name with extension
- The answer field is populated with the file name without the extension