### PR TITLE
BUGFIX: Prevent loss of state when no category is declared

### DIFF
--- a/src/TriviaInputForm.js
+++ b/src/TriviaInputForm.js
@@ -45,8 +45,8 @@ const TriviaInputForm = ({
             alert('Please enter a category');
             return;
         };
-        setElapsedSeconds(0);
         if (categoryType === 'T') {
+            setElapsedSeconds(0);
             setTimerActive(true)
         };
         onSubmit(e);

--- a/src/TriviaInputForm.js
+++ b/src/TriviaInputForm.js
@@ -40,11 +40,11 @@ const TriviaInputForm = ({
     }, [dataLoaded]);
 
     const handleSubmit = (e) => {
+        e.preventDefault();
         if (categoryInput === '') {
             alert('Please enter a category');
             return;
         };
-        e.preventDefault();
         setElapsedSeconds(0);
         if (categoryType === 'T') {
             setTimerActive(true)


### PR DESCRIPTION
Bug discovered on 25 June 2023: if no category has been input and user clicks the "generate" or "create blank pairs" button then a form submission takes place which does not prevent the default behavior of the event (which involves refreshing the page).

The bugfix is a one-liner change to move the prevention of the default behavior prior to the check on whether the category input field is blank.

There is an additional very minor change in this PR which places the resetting of the elapsed seconds counter to take place only when the category is Text (because this state change isn't relevant when any other categories are selected).