### PR TITLE
Add ability to update category names after generation

### DIFF
--- a/src/EditableCategoryName.js
+++ b/src/EditableCategoryName.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const EditableCategoryName = ({
+    categoryName,
+    onCollapseChange
+}) => {
+    return (
+        <div
+            onClick={onCollapseChange}
+            style={{
+                fontSize: '1.5rem',
+                fontWeight: 'bold',
+            }}
+        >
+            {categoryName}
+        </div>
+    )
+}
+
+export default EditableCategoryName;

--- a/src/EditableCategoryName.js
+++ b/src/EditableCategoryName.js
@@ -22,7 +22,7 @@ const EditableCategoryName = ({
             value={localCategoryName}
             onChange={handleChange}
             onBlur={handleBlur}
-            sx={{ width: '25%' }}
+            fullWidth
         />
     )
 }

--- a/src/EditableCategoryName.js
+++ b/src/EditableCategoryName.js
@@ -1,19 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
+
+import { TextField } from '@mui/material';
 
 const EditableCategoryName = ({
     categoryName,
-    onCollapseChange
+    onCategoryNameChange
 }) => {
+    const [localCategoryName, setLocalCategoryName] = useState(categoryName);
+
+    const handleBlur = () => {
+        onCategoryNameChange(localCategoryName);
+    };
+
+    const handleChange = (event) => {
+        setLocalCategoryName(event.target.value);
+    };
+
     return (
-        <div
-            onClick={onCollapseChange}
-            style={{
-                fontSize: '1.5rem',
-                fontWeight: 'bold',
-            }}
-        >
-            {categoryName}
-        </div>
+        <TextField
+            label="Category Name"
+            value={localCategoryName}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            sx={{ width: '25%' }}
+        />
     )
 }
 

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 
-import { Button, Container } from '@mui/material';
+import { Button, Container, Grid } from '@mui/material';
 
 import EditableCategoryName from './EditableCategoryName';
 import EditableQuestionAnswerPair from './EditableQuestionAnswerPair';
@@ -264,22 +264,28 @@ const TriviaGenerator = () => {
                 {
                     questionsByCategory.map((categoryObj) => (
                         <div key={categoryObj.category} className="category">
-                            <h3 onClick={() => setCollapsed({ ...collapsed, [categoryObj.category]: !collapsed[categoryObj.category] })}>
-                                {collapsed[categoryObj.category] ? String.fromCharCode(0x02192) : String.fromCharCode(0x02193)}
-                            </h3>
-                            <EditableCategoryName
-                                categoryName={categoryObj.category}
-                                onCategoryNameChange={(newCategoryName) => {
-                                    setQuestionsByCategory((prevState) => {
-                                        const updatedQuestionsByCategory = [...prevState];
-                                        const categoryIndex = updatedQuestionsByCategory.findIndex(
-                                            (item) => item.category === categoryObj.category
-                                        );
-                                        updatedQuestionsByCategory[categoryIndex].category = newCategoryName;
-                                        return updatedQuestionsByCategory;
-                                    });
-                                }}
-                            />
+                            <Grid container>
+                                <Grid item>
+                                    <EditableCategoryName
+                                        categoryName={categoryObj.category}
+                                        onCategoryNameChange={(newCategoryName) => {
+                                            setQuestionsByCategory((prevState) => {
+                                                const updatedQuestionsByCategory = [...prevState];
+                                                const categoryIndex = updatedQuestionsByCategory.findIndex(
+                                                    (item) => item.category === categoryObj.category
+                                                );
+                                                updatedQuestionsByCategory[categoryIndex].category = newCategoryName;
+                                                return updatedQuestionsByCategory;
+                                            });
+                                        }}
+                                    />
+                                </Grid>
+                                <Grid item>
+                                    <h3 style={{ marginLeft: "10px" }} onClick={() => setCollapsed({ ...collapsed, [categoryObj.category]: !collapsed[categoryObj.category] })}>
+                                        {collapsed[categoryObj.category] ? String.fromCharCode(0x02192) : String.fromCharCode(0x02193)}
+                                    </h3>
+                                </Grid>
+                            </Grid>
                             {!collapsed[categoryObj.category] && categoryObj.questions.map((questionObj, index) => (
                                 <EditableQuestionAnswerPair
                                     key={index}

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -269,7 +269,16 @@ const TriviaGenerator = () => {
                             </h3>
                             <EditableCategoryName
                                 categoryName={categoryObj.category}
-                                onCollapseChange={() => setCollapsed({ ...collapsed, [categoryObj.category]: !collapsed[categoryObj.category] })}
+                                onCategoryNameChange={(newCategoryName) => {
+                                    setQuestionsByCategory((prevState) => {
+                                        const updatedQuestionsByCategory = [...prevState];
+                                        const categoryIndex = updatedQuestionsByCategory.findIndex(
+                                            (item) => item.category === categoryObj.category
+                                        );
+                                        updatedQuestionsByCategory[categoryIndex].category = newCategoryName;
+                                        return updatedQuestionsByCategory;
+                                    });
+                                }}
                             />
                             {!collapsed[categoryObj.category] && categoryObj.questions.map((questionObj, index) => (
                                 <EditableQuestionAnswerPair

--- a/src/TriviaGenerator.js
+++ b/src/TriviaGenerator.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 
 import { Button, Container } from '@mui/material';
 
+import EditableCategoryName from './EditableCategoryName';
 import EditableQuestionAnswerPair from './EditableQuestionAnswerPair';
 import TriviaInputForm from './TriviaInputForm';
 
@@ -264,8 +265,12 @@ const TriviaGenerator = () => {
                     questionsByCategory.map((categoryObj) => (
                         <div key={categoryObj.category} className="category">
                             <h3 onClick={() => setCollapsed({ ...collapsed, [categoryObj.category]: !collapsed[categoryObj.category] })}>
-                                {categoryObj.category} {collapsed[categoryObj.category] ? String.fromCharCode(0x02192) : String.fromCharCode(0x02193)}
+                                {collapsed[categoryObj.category] ? String.fromCharCode(0x02192) : String.fromCharCode(0x02193)}
                             </h3>
+                            <EditableCategoryName
+                                categoryName={categoryObj.category}
+                                onCollapseChange={() => setCollapsed({ ...collapsed, [categoryObj.category]: !collapsed[categoryObj.category] })}
+                            />
                             {!collapsed[categoryObj.category] && categoryObj.questions.map((questionObj, index) => (
                                 <EditableQuestionAnswerPair
                                     key={index}


### PR DESCRIPTION
User can update category names (à la question and answer text fields) after they're generated.