### PR TITLE
Start app in dev mode to use mock API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,30 @@
-Create environment variable:
+# Trivia Harvest
+
+A React- and Express-based app that uses the OpenAI API to generate trivia questions and answers from a given category, lets the user edit or modify them, then saves the file in a custom format.
+
+## Setup
+
+Create an environment variable for your OpenAI API key:
+
 - `OPENAI_API_KEY=<OpenAI API key>`
 
 Then:
 
 - `npm install` to install dependencies
-- `npm start` to start both server and React front-end
+- `npm start` to start both Express server and React front-end
+
+## Usage
+
+- Select category type (i.e. Text, Image, or Audio)
 - Input trivia category and number of questions to generate
-- When candidate question/answer pairs are returned:
-  - (Optional) edit the question and/or answer
-  - Mark difficulty on at least one question
-  - Click 'Save TXT' button and questions will be sorted from easiest to most difficult and then exported to a custom file format in the `./output/` directory
+- For Text category type:
+   - Call is made to OpenAI API to generate questions and answers
+   - Edit the question and/or answer
+- For Image or Audio category type:
+   - Five blank pairs are returned
+   - Input file path (or use file manager to select file)
+- For all question/answer pairs, select 2 Easy, 2 Medium, and 1 Difficult before generating the next category
+- When finished, click "Save" to save the file in a custom format to the `output` folder
+
+## Other / Notes
+- To run the app in development mode, use `npm run dev`. The response from the OpenAI API will be mocked.

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "main": "generateTriviaQuestions.js",
     "scripts": {
         "server": "node server-entrypoint.js",
+        "server-mock": "node server-entrypoint.js --mockApi",
         "client": "PORT=3001 react-scripts start",
         "start": "concurrently \"npm run server\" \"npm run client\"",
         "build": "react-scripts build",
         "test": "react-scripts test",
-        "eject": "react-scripts eject"
+        "eject": "react-scripts eject",
+        "dev": "concurrently \"npm run server-mock\" \"npm run client\""
     },
     "keywords": [],
     "author": "",

--- a/server-utils/generateTriviaQuestions.js
+++ b/server-utils/generateTriviaQuestions.js
@@ -41,7 +41,7 @@ const getApiCall = async (data, numQuestions) => {
                         ]
                     }
                 });
-            }, 1000); // <-- If we want to adjust the delay, e.g. for testing the seconds-elapsed timer.
+            }, 1000);
         });
     } else {
         return await openai.createCompletion(data);

--- a/server-utils/generateTriviaQuestions.js
+++ b/server-utils/generateTriviaQuestions.js
@@ -36,7 +36,7 @@ const getApiCall = async (data, numQuestions) => {
                     data: {
                         choices: [
                             {
-                                text: 'Q: What is the capital of Ohio?\nA: Columbus.\n'.repeat(numQuestions)
+                                text: 'Q: Am I running in dev mode using mocked API calls?\nA: Yes, I am.\n'.repeat(numQuestions)
                             }
                         ]
                     }

--- a/server-utils/generateTriviaQuestions.js
+++ b/server-utils/generateTriviaQuestions.js
@@ -22,6 +22,32 @@ const parseQaPairs = rawQuestions => {
         }));
 };
 
+const getApiCall = async (data, numQuestions) => {
+    if (process.argv.includes('--mockApi')) {
+        console.log(`\
+👷‍♂️👷‍♂️------------------👷‍♂️👷‍♂️------------------👷‍♂️👷‍♂️
+             You are in DEV mode!
+          API calls will be mocked.
+👷‍♂️👷‍♂️------------------👷‍♂️👷‍♂️------------------👷‍♂️👷‍♂️`);
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve({
+                    data: {
+                        choices: [
+                            {
+                                text: 'Q: What is the capital of Ohio?\nA: Columbus.\n'.repeat(numQuestions)
+                            }
+                        ]
+                    }
+                });
+            }, 1000); // <-- If we want to adjust the delay, e.g. for testing the seconds-elapsed timer.
+        });
+    } else {
+        return await openai.createCompletion(data);
+    }
+};
+
 const generateTriviaQuestions = async (category, numQuestions) => {
     try {
         const prompt = buildPrompt(category, numQuestions);
@@ -34,7 +60,7 @@ const generateTriviaQuestions = async (category, numQuestions) => {
         console.log('🟢 Querying ChatGPT API with the following params: 🟢');
         console.log(data);
 
-        const response = await openai.createCompletion(data);
+        const response = await getApiCall(data, numQuestions);
         console.log('🟢 Response (response.data) from ChatGPT API: 🟢');
         console.log(response.data);
         const text = formatApiResponse(response);


### PR DESCRIPTION
Running `npm run dev` to start the app will cause the server to mock API responses when Text category is submitted. The intended purpose of this feature is to a) speed up the response of Text QA pairs during development, and b) reduce billing usage on API keys.

The README was also updated.